### PR TITLE
logger_setup.py: fix default and plain logging formats

### DIFF
--- a/bin/logger_setup.py
+++ b/bin/logger_setup.py
@@ -98,9 +98,9 @@ class ScreenFormatter(logging.Formatter):
     format than other log levels.
     """
 
-    plain_format = "%(msg)s"
+    plain_format = "%(message)s"
 
-    def __init__(self, fmt="%(levelname)s: %(msg)s", plain_log_level=15):
+    def __init__(self, fmt="%(levelname)s: %(message)s", plain_log_level=15):
         self.plain_log_level = plain_log_level
         logging.Formatter.__init__(self, fmt)
 


### PR DESCRIPTION
The logging format by default and when used with plain()
log level uses raw %(msg) format record.

This makes logger calls with parameters to ignore all
parameters in the log output.

Instead of %(msg), use %(message) which is the record attribute
with msg and the parameters included.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>