### PR TITLE
argparse_setup.py/flatten_mirror.py

### DIFF
--- a/bin/argparse_setup.py
+++ b/bin/argparse_setup.py
@@ -15,6 +15,15 @@
 
 # Note this class MUST run in both python2 and python3
 
+# pylint: disable=attribute-defined-outside-init
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-statements
+# pylint: disable=bare-except
+# pylint: disable=misplaced-bare-raise
+# pylint: disable=too-many-nested-blocks
+# pylint: disable=no-self-use
+
+
 import argparse
 import sys
 

--- a/bin/flatten_mirror.py
+++ b/bin/flatten_mirror.py
@@ -33,6 +33,14 @@
 # A special folder name '[SKIP]' is defined when you are intentionally
 # skipping a layer.
 
+# pylint: disable=attribute-defined-outside-init
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-statements
+# pylint: disable=bare-except
+# pylint: disable=misplaced-bare-raise
+# pylint: disable=too-many-nested-blocks
+# pylint: disable=no-self-use
+
 import argparse
 
 import os

--- a/bin/layer_index.py
+++ b/bin/layer_index.py
@@ -13,6 +13,14 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
+# pylint: disable=attribute-defined-outside-init
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-statements
+# pylint: disable=bare-except
+# pylint: disable=misplaced-bare-raise
+# pylint: disable=too-many-nested-blocks
+# pylint: disable=no-self-use
+
 import json
 
 import sys

--- a/bin/setup.py
+++ b/bin/setup.py
@@ -15,6 +15,15 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
+# pylint: disable=attribute-defined-outside-init
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-statements
+# pylint: disable=bare-except
+# pylint: disable=misplaced-bare-raise
+# pylint: disable=too-many-nested-blocks
+# pylint: disable=no-self-use
+
+
 # Please keep these sorted.
 import logging
 import os


### PR DESCRIPTION
layer_index.py/setup.py: turn off some lint control options

No functionality changed. pylint rate: 9.70/10

Signed-off-by: Cheng Li <cheng.li@windriver.com>


<If you don't  like adding those # pylint: disable= ... stuff,  
Please discard this update>